### PR TITLE
fix: detect Snap/Flatpak browser installs on Linux

### DIFF
--- a/src/extractors/brave.py
+++ b/src/extractors/brave.py
@@ -17,6 +17,10 @@ class BraveExtractor(ChromiumExtractor):
     )
     user_data_dirs_linux = (
         ".config/BraveSoftware/Brave-Browser",
+        # Snap (the `brave` snap keeps config under current/).
+        "snap/brave/current/.config/BraveSoftware/Brave-Browser",
+        # Flatpak (com.brave.Browser).
+        ".var/app/com.brave.Browser/config/BraveSoftware/Brave-Browser",
     )
 
     keychain_service = "Brave Safe Storage"

--- a/src/extractors/chrome.py
+++ b/src/extractors/chrome.py
@@ -17,6 +17,8 @@ class ChromeExtractor(ChromiumExtractor):
     )
     user_data_dirs_linux = (
         ".config/google-chrome",
+        # Flatpak (com.google.Chrome).
+        ".var/app/com.google.Chrome/config/google-chrome",
     )
 
     keychain_service = "Chrome Safe Storage"

--- a/src/extractors/edge.py
+++ b/src/extractors/edge.py
@@ -17,6 +17,8 @@ class EdgeExtractor(ChromiumExtractor):
     )
     user_data_dirs_linux = (
         ".config/microsoft-edge",
+        # Flatpak (com.microsoft.Edge).
+        ".var/app/com.microsoft.Edge/config/microsoft-edge",
     )
 
     keychain_service = "Microsoft Edge Safe Storage"

--- a/src/extractors/firefox.py
+++ b/src/extractors/firefox.py
@@ -60,13 +60,40 @@ _ROOT_IDS = {
 }
 
 
-def _firefox_profiles_root() -> Path | None:
+def _firefox_profiles_roots() -> list[Path]:
+    """Every plausible Firefox profiles root for the current OS.
+
+    On Linux the profile location depends on how Firefox was packaged:
+    a classic distro/apt install uses ``~/.mozilla/firefox``, but the
+    Snap build (the default on Ubuntu 22.04+) lives under
+    ``~/snap/firefox/common/.mozilla/firefox`` and the Flatpak build
+    under ``~/.var/app/org.mozilla.firefox/.mozilla/firefox``. We probe
+    all three so a Snap/Flatpak user isn't told Firefox is "not
+    installed".
+    """
     home = Path.home()
     if sys.platform == "darwin":
-        return home / "Library/Application Support/Firefox"
+        return [home / "Library/Application Support/Firefox"]
     if os.name == "nt":
-        return home / "AppData/Roaming/Mozilla/Firefox"
-    return home / ".mozilla/firefox"
+        return [home / "AppData/Roaming/Mozilla/Firefox"]
+    return [
+        home / ".mozilla/firefox",
+        home / "snap/firefox/common/.mozilla/firefox",
+        home / ".var/app/org.mozilla.firefox/.mozilla/firefox",
+    ]
+
+
+def _firefox_profiles_root() -> Path | None:
+    """First candidate root that has a ``profiles.ini``, else the first
+    candidate that merely exists, else the canonical-but-missing one."""
+    candidates = _firefox_profiles_roots()
+    for root in candidates:
+        if (root / "profiles.ini").is_file():
+            return root
+    for root in candidates:
+        if root.is_dir():
+            return root
+    return candidates[0] if candidates else None
 
 
 class FirefoxExtractor(BrowserExtractor):
@@ -171,6 +198,18 @@ class FirefoxExtractor(BrowserExtractor):
     def extract(self) -> ExportData:
         profiles = self.profile_paths()
         if not profiles:
+            # Distinguish "Firefox isn't here at all" from "Firefox is
+            # installed but the profile was never opened, so there's no
+            # places.sqlite yet" — the latter is a common point of
+            # confusion when the Detect screen says Firefox is present.
+            root = _firefox_profiles_root()
+            if root is not None and (root / "profiles.ini").is_file():
+                raise BrowserExtractorError(
+                    "no_firefox_profile_data",
+                    "Firefox is installed but its profile has no data yet "
+                    "(places.sqlite is missing). Launch Firefox once so it "
+                    "initialises the profile, then try again.",
+                )
             raise BrowserExtractorError(
                 "no_firefox_profiles",
                 "Firefox has no profile directory on this machine.",

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -113,6 +113,46 @@ def test_firefox_extractor_skips_disabled_root(firefox_home):
     assert "Bookmarks Menu" not in folder_titles
 
 
+@pytest.mark.parametrize(
+    "root_rel",
+    [
+        "snap/firefox/common/.mozilla/firefox",                 # Ubuntu Snap
+        ".var/app/org.mozilla.firefox/.mozilla/firefox",        # Flatpak
+    ],
+)
+def test_firefox_extractor_detects_linux_packaged_install(
+    tmp_path, monkeypatch, root_rel
+):
+    """Snap/Flatpak Firefox keeps its profiles outside ``~/.mozilla``;
+    detection must find those too (regression for the Reddit report that
+    Firefox wasn't detected)."""
+    import shutil
+    import sys
+    from pathlib import Path
+
+    from extractors import FirefoxExtractor
+
+    fixtures = Path(__file__).resolve().parent / "fixtures" / "firefox"
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    # Re-anchor the Firefox fixture tree under the packaged root instead
+    # of the macOS ``Library/Application Support/Firefox`` location.
+    for src in fixtures.rglob("*"):
+        if src.is_file():
+            dest = home / root_rel / src.relative_to(fixtures)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dest)
+
+    ext = FirefoxExtractor()
+    assert ext.is_installed() is True
+    data = ext.extract()
+    assert data.source == "firefox"
+    assert len(data.spaces) == 1
+
+
 # ----- Safari -------------------------------------------------------------
 
 def test_safari_extractor_detects_fixture(safari_home):


### PR DESCRIPTION
## Why

A Reddit user reported browser2zen didn't detect their installed Firefox. Root cause: Firefox detection hardcoded `~/.mozilla/firefox`, but on Linux the profile location depends on how Firefox was packaged. The **Snap** build — the default on Ubuntu 22.04+ — keeps profiles under `~/snap/firefox/common/.mozilla/firefox`, and **Flatpak** under `~/.var/app/org.mozilla.firefox/.mozilla/firefox`. Neither was probed, so the Detect screen reported Firefox as "not installed."

## What changed

**Firefox** (`src/extractors/firefox.py`)
- `_firefox_profiles_root()` now scans candidate roots (standard + Snap + Flatpak) and picks the first with a `profiles.ini`, mirroring how Arc detection already does multi-path lookup.
- The "installed but never launched" case (profile exists, no `places.sqlite` yet) now raises a distinct `no_firefox_profile_data` error instead of the misleading "no profile directory" message.

**Chromium family** — already resolved a tuple of candidate user-data dirs via `_first_existing()`, but each subclass listed only one Linux path. Added packaged-install locations:
- Chrome — Flatpak `com.google.Chrome`
- Brave — Snap `brave` + Flatpak `com.brave.Browser`
- Edge — Flatpak `com.microsoft.Edge`

> Note: Chromium cookie decryption on Linux still raises `unsupported_platform` (pre-existing, separate concern) — but bookmarks/history migrate fine cross-platform, so detection was the real blocker.

## Tests

- Added a parametrized regression test covering both Snap and Flatpak Firefox layouts under a pinned `linux` platform.
- Full suite green (51 passed, 1 pre-existing skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)