### PR TITLE
fix(orchestrator): name the real source browser in cookie-skip messages

### DIFF
--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -123,23 +123,25 @@ def _step_label(step: str, source_display: str) -> str:
 
 # User-facing messages mapped from the structured error codes the
 # Chromium cookie importer surfaces. Kept at module scope so the
-# orchestrator's `_run` method stays focused on flow.
+# orchestrator's `_run` method stays focused on flow. ``{source}`` is
+# filled with the active source-browser display name at emit time, so an
+# Edge/Chrome/Brave user never sees a message that says "Arc".
 _COOKIE_ERROR_MESSAGES = {
     # macOS
     "keychain_denied":
         "macOS Keychain access was denied; cookies skipped.",
     # Windows DPAPI / Chromium-family
     "chromium_local_state_missing":
-        "Arc has not been launched on this Windows account yet; cookies skipped.",
+        "{source} has not been launched on this Windows account yet; cookies skipped.",
     "chromium_no_encrypted_key":
-        "Arc has no cookie encryption key on this account; cookies skipped.",
+        "{source} has no cookie encryption key on this account; cookies skipped.",
     "chromium_appbound_encryption":
-        "Arc cookies use newer (v20) app-bound encryption; cookies skipped. "
+        "{source} cookies use newer (v20) app-bound encryption; cookies skipped. "
         "Sign in fresh on imported sites.",
     "chromium_unknown_key_prefix":
-        "Arc Local State key has an unrecognised prefix; cookies skipped.",
+        "{source} Local State key has an unrecognised prefix; cookies skipped.",
     "chromium_unexpected_key_length":
-        "Arc DPAPI key has unexpected length; cookies skipped.",
+        "{source} DPAPI key has unexpected length; cookies skipped.",
     "dpapi_wrong_user":
         "Cookies were encrypted on a different Windows account and can't be "
         "migrated. Sign in fresh on imported sites.",
@@ -520,7 +522,9 @@ class MigrationOrchestrator:
                 summary = c.import_cookies()
                 if summary.get("error"):
                     err = summary["error"]
-                    msg = _COOKIE_ERROR_MESSAGES.get(err, f"Cookie import failed: {err}")
+                    msg = _COOKIE_ERROR_MESSAGES.get(
+                        err, f"Cookie import failed: {err}"
+                    ).format(source=self.source.display_name)
                     self._error_step("cookies", RuntimeError(msg))
                 else:
                     self._done_step("cookies", summary=summary)


### PR DESCRIPTION
## What

The cookie-error strings in `_COOKIE_ERROR_MESSAGES` (`app/orchestrator.py`) were hardcoded to say **"Arc"**. When cookies were skipped for any other source, the user saw a message about Arc instead of their actual browser.

This is most visible on **current Edge on Windows**, where app-bound (v20) cookie encryption *always* triggers the skip, so an Edge user reliably saw *"Arc cookies use newer (v20) app-bound encryption…"*. Surfaced by a Reddit report ("Edge to Zen… no active logins, no cookies").

## Change

- Template the five Chromium-family messages with `{source}`.
- Fill `{source}` with the active extractor's `display_name` at emit time (e.g. "Microsoft Edge", "Google Chrome", "Brave").
- Messages without a placeholder (Keychain, DPAPI-wrong-user, Firefox, Safari) `.format()` to a harmless no-op.

## Scope / not included

- Does **not** fix Edge cookie migration itself — app-bound encryption is a hard wall (needs Edge's elevated decryptor). This only corrects the messaging.
- Does **not** touch the "no active tabs" issue, which needs a real Edge `Session_` sample to root-cause (tracking separately with the reporter).

## Testing

Verified all 12 messages format cleanly with a source name via isolated dict extraction. ⚠️ Full `pytest tests/` was **not** run locally (dev interpreter lacks `lz4`/`pytest`) — please confirm CI green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)