### PR TITLE
fix(extractors): detect Arch XDG-config + Flatpak browsers (Brave Origin, Firefox, Zen)

### DIFF
--- a/app/bridge.py
+++ b/app/bridge.py
@@ -369,7 +369,8 @@ class Bridge:
         from .env_check import list_zen_profiles
         return [
             {"name": p.name, "path": str(p.path),
-             "isRelease": p.is_release, "hasZenSessions": p.has_zen_sessions}
+             "isRelease": p.is_release, "hasZenSessions": p.has_zen_sessions,
+             "install": p.install}
             for p in list_zen_profiles()
         ]
 

--- a/app/env_check.py
+++ b/app/env_check.py
@@ -111,13 +111,62 @@ def _arc_profiles(user_data: Path | None) -> list[str]:
 # ---------- Zen ----------
 
 
-def _zen_profiles_root() -> Path:
+def _xdg_config_home() -> Path:
+    """Resolve ``$XDG_CONFIG_HOME``, defaulting to ``~/.config``.
+
+    XDG-aware builds (common on Arch) keep browser data under
+    ``$XDG_CONFIG_HOME`` instead of the classic dotdir; honour the
+    variable when the user sets it.
+    """
+    env = os.environ.get("XDG_CONFIG_HOME")
+    if env:
+        return Path(env).expanduser()
+    return Path.home() / ".config"
+
+
+def _zen_profiles_roots() -> list[Path]:
     home = Path.home()
     if sys.platform == "darwin":
-        return home / "Library/Application Support/zen/Profiles"
+        return [home / "Library/Application Support/zen/Profiles"]
     if os.name == "nt":
-        return home / "AppData/Roaming/zen/Profiles"
-    return home / ".zen"
+        return [home / "AppData/Roaming/zen/Profiles"]
+    return [
+        home / ".zen",
+        _xdg_config_home() / "zen",
+    ]
+
+
+def _zen_root_has_profile(root: Path) -> bool:
+    """A Zen root is live if any of its profile subdirectories carries a
+    ``places.sqlite`` (the heuristic ``list_zen_profiles`` uses). This
+    stops a stale ``profiles.ini`` from an old/uninstalled Zen from
+    shadowing a real profile under another candidate root."""
+    try:
+        return any(
+            entry.is_dir() and (entry / "places.sqlite").is_file()
+            for entry in root.iterdir()
+        )
+    except OSError:
+        return False
+
+
+def _zen_profiles_root() -> Path:
+    """First candidate root that holds a live profile, else the first
+    candidate with a ``profiles.ini``, else the first candidate that
+    merely exists, else the canonical-but-missing one. ``~/.zen`` stays
+    first so classic installs are unchanged; the XDG ``~/.config/zen``
+    location covers Arch-style installs."""
+    candidates = _zen_profiles_roots()
+    for root in candidates:
+        if _zen_root_has_profile(root):
+            return root
+    for root in candidates:
+        if (root / "profiles.ini").is_file():
+            return root
+    for root in candidates:
+        if root.is_dir():
+            return root
+    return candidates[0] if candidates else None
 
 
 def list_zen_profiles() -> list[ZenProfile]:

--- a/app/env_check.py
+++ b/app/env_check.py
@@ -133,6 +133,9 @@ def _zen_profiles_roots() -> list[Path]:
     return [
         home / ".zen",
         _xdg_config_home() / "zen",
+        # Flatpak (app.zen_browser.zen) keeps its data under the sandbox
+        # home, not the host ~/.zen or ~/.config/zen.
+        home / ".var/app/app.zen_browser.zen/.zen",
     ]
 
 
@@ -155,7 +158,8 @@ def _zen_profiles_root() -> Path:
     candidate with a ``profiles.ini``, else the first candidate that
     merely exists, else the canonical-but-missing one. ``~/.zen`` stays
     first so classic installs are unchanged; the XDG ``~/.config/zen``
-    location covers Arch-style installs."""
+    location covers Arch-style installs; the Flatpak sandbox home covers
+    ``app.zen_browser.zen`` installs."""
     candidates = _zen_profiles_roots()
     for root in candidates:
         if _zen_root_has_profile(root):

--- a/app/env_check.py
+++ b/app/env_check.py
@@ -25,6 +25,7 @@ class ZenProfile:
     path: Path
     is_release: bool          # cheap heuristic: name contains "release"
     has_zen_sessions: bool    # zen-sessions.jsonlz4 exists (modern format)
+    install: str = ""         # "", "XDG" or "Flatpak" — qualifies the picker
 
 
 @dataclass(frozen=True)
@@ -124,76 +125,69 @@ def _xdg_config_home() -> Path:
     return Path.home() / ".config"
 
 
-def _zen_profiles_roots() -> list[Path]:
+def _zen_profiles_roots() -> list[tuple[str, Path]]:
+    """Every plausible Zen profiles root, each with a short install label.
+
+    The label disambiguates the picker when the same profile name exists
+    under more than one root (a native Zen and a Flatpak Zen side by
+    side). It is empty for the classic location, which is the common
+    case and needs no qualifier.
+    """
     home = Path.home()
     if sys.platform == "darwin":
-        return [home / "Library/Application Support/zen/Profiles"]
+        return [("", home / "Library/Application Support/zen/Profiles")]
     if os.name == "nt":
-        return [home / "AppData/Roaming/zen/Profiles"]
+        return [("", home / "AppData/Roaming/zen/Profiles")]
     return [
-        home / ".zen",
-        _xdg_config_home() / "zen",
+        ("", home / ".zen"),
+        # XDG-aware builds (common on Arch) put the root under
+        # $XDG_CONFIG_HOME instead of the classic dotdir.
+        ("XDG", _xdg_config_home() / "zen"),
         # Flatpak (app.zen_browser.zen) keeps its data under the sandbox
         # home, not the host ~/.zen or ~/.config/zen.
-        home / ".var/app/app.zen_browser.zen/.zen",
+        ("Flatpak", home / ".var/app/app.zen_browser.zen/.zen"),
     ]
 
 
-def _zen_root_has_profile(root: Path) -> bool:
-    """A Zen root is live if any of its profile subdirectories carries a
-    ``places.sqlite`` (the heuristic ``list_zen_profiles`` uses). This
-    stops a stale ``profiles.ini`` from an old/uninstalled Zen from
-    shadowing a real profile under another candidate root."""
-    try:
-        return any(
-            entry.is_dir() and (entry / "places.sqlite").is_file()
-            for entry in root.iterdir()
-        )
-    except OSError:
-        return False
-
-
-def _zen_profiles_root() -> Path:
-    """First candidate root that holds a live profile, else the first
-    candidate with a ``profiles.ini``, else the first candidate that
-    merely exists, else the canonical-but-missing one. ``~/.zen`` stays
-    first so classic installs are unchanged; the XDG ``~/.config/zen``
-    location covers Arch-style installs; the Flatpak sandbox home covers
-    ``app.zen_browser.zen`` installs."""
-    candidates = _zen_profiles_roots()
-    for root in candidates:
-        if _zen_root_has_profile(root):
-            return root
-    for root in candidates:
-        if (root / "profiles.ini").is_file():
-            return root
-    for root in candidates:
-        if root.is_dir():
-            return root
-    return candidates[0] if candidates else None
-
-
 def list_zen_profiles() -> list[ZenProfile]:
-    root = _zen_profiles_root()
-    if not root.is_dir():
-        return []
+    """Every live Zen profile across every candidate root.
+
+    We scan all roots rather than picking one, for two reasons: a stale
+    ``~/.zen`` left by an uninstalled Zen must not shadow a live profile
+    elsewhere, and a machine can genuinely run a native Zen and a Flatpak
+    Zen at once. Both then show up in the profile picker instead of the
+    tool silently choosing for the user.
+    """
     result: list[ZenProfile] = []
-    for entry in sorted(root.iterdir()):
-        if not entry.is_dir():
+    seen: set[Path] = set()
+    for install, root in _zen_profiles_roots():
+        try:
+            entries = sorted(root.iterdir())
+        except OSError:
             continue
-        # Heuristic: a real profile has at least places.sqlite
-        if not (entry / "places.sqlite").is_file():
-            continue
-        name = entry.name.split(".", 1)[1] if "." in entry.name else entry.name
-        result.append(
-            ZenProfile(
-                name=name,
-                path=entry,
-                is_release="release" in entry.name.lower(),
-                has_zen_sessions=(entry / "zen-sessions.jsonlz4").is_file(),
+        for entry in entries:
+            if not entry.is_dir():
+                continue
+            # Heuristic: a real profile has at least places.sqlite
+            if not (entry / "places.sqlite").is_file():
+                continue
+            resolved = entry.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            name = entry.name.split(".", 1)[1] if "." in entry.name else entry.name
+            result.append(
+                ZenProfile(
+                    name=name,
+                    path=entry,
+                    is_release="release" in entry.name.lower(),
+                    has_zen_sessions=(entry / "zen-sessions.jsonlz4").is_file(),
+                    install=install,
+                )
             )
-        )
-    # Prefer release-labelled profiles first
+    # Prefer release-labelled profiles first. The sort is stable, so
+    # within a tie the root order above wins (classic before XDG before
+    # Flatpak), keeping single-install machines on their old profile.
     result.sort(key=lambda p: (not p.is_release, p.name.lower()))
     return result
 
@@ -367,6 +361,7 @@ def env_report_to_dict(report: EnvReport) -> dict:
                 "path": str(p.path),
                 "isRelease": p.is_release,
                 "hasZenSessions": p.has_zen_sessions,
+                "install": p.install,
             }
             for p in report.zen_profiles
         ],

--- a/app/frontend/app.js
+++ b/app/frontend/app.js
@@ -367,8 +367,15 @@ function renderDetect(env) {
       zenSelect.style.display = "";
       clear(zenSelect);
       env.zenProfiles.forEach((p, i) => {
+        // `install` ("XDG" / "Flatpak") tells two same-named profiles
+        // apart when a native and a sandboxed Zen sit side by side.
+        // The dir name usually already carries "(release)", so only add
+        // that tag when it doesn't.
+        const tags = [];
+        if (p.isRelease && !/release/i.test(p.name)) tags.push("release");
+        if (p.install) tags.push(p.install);
         zenSelect.appendChild(el("option", {value: p.path, selected: i === 0,
-          text: p.name + (p.isRelease ? " (release)" : "")}));
+          text: p.name + (tags.length ? ` (${tags.join(", ")})` : "")}));
       });
       state.selectedZenProfile = env.zenProfiles[0].path;
       zenSelect.onchange = () => { state.selectedZenProfile = zenSelect.value; updateGate(state.env); };

--- a/src/extractors/base.py
+++ b/src/extractors/base.py
@@ -27,12 +27,31 @@ originated from.
 from __future__ import annotations
 
 import logging
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------- paths
+
+
+def xdg_config_home() -> Path:
+    """Resolve ``$XDG_CONFIG_HOME``, defaulting to ``~/.config``.
+
+    Both Firefox and Chromium read their Linux profile root from this
+    variable, so XDG-aware builds (common on Arch) end up outside the
+    classic ``~/.config`` when the user sets it. ``app/env_check.py``
+    keeps its own copy on purpose: it is deliberately importable without
+    ``src`` on ``sys.path``.
+    """
+    env = os.environ.get("XDG_CONFIG_HOME")
+    if env:
+        return Path(env).expanduser()
+    return Path.home() / ".config"
 
 
 # --------------------------------------------------------------------- payload

--- a/src/extractors/brave.py
+++ b/src/extractors/brave.py
@@ -17,6 +17,14 @@ class BraveExtractor(ChromiumExtractor):
     )
     user_data_dirs_linux = (
         ".config/BraveSoftware/Brave-Browser",
+        # Brave Origin — the minimalist/debloated build shipped by the
+        # official ``brave-origin-bin`` AUR package. It keeps its own
+        # User Data dir under ``BraveSoftware/Brave-Origin[-Beta|-Nightly]``
+        # instead of ``Brave-Browser``. Snap / Flatpak variants mirror the
+        # ``Brave-Browser`` layout, so the same container paths apply.
+        ".config/BraveSoftware/Brave-Origin",
+        ".config/BraveSoftware/Brave-Origin-Beta",
+        ".config/BraveSoftware/Brave-Origin-Nightly",
         # Snap (the `brave` snap keeps config under current/).
         "snap/brave/current/.config/BraveSoftware/Brave-Browser",
         # Flatpak (com.brave.Browser).

--- a/src/extractors/chromium.py
+++ b/src/extractors/chromium.py
@@ -36,6 +36,7 @@ from .base import (
     FolderRecord,
     SpaceRecord,
     TabRecord,
+    xdg_config_home,
 )
 
 logger = logging.getLogger(__name__)
@@ -49,17 +50,20 @@ _NS_SPACE = uuid.UUID("0ad3a9d9-95c0-4de1-87c1-2c41a9a3b1aa")
 
 
 def _root_has_profile(root: Path) -> bool:
-    """A Chromium User Data root is live if it carries a ``Local State``
-    file (created on first launch) or any profile subdirectory with a
-    ``Bookmarks`` / ``History`` file. An empty leftover install dir
-    (e.g. an abandoned ``Brave-Browser`` next to a used ``Brave-Origin``)
-    must not shadow the real one."""
-    if (root / "Local State").is_file():
-        return True
+    """A Chromium User Data root is live if it holds a profile dir with a
+    ``Bookmarks`` file. An empty leftover install dir (e.g. an abandoned
+    ``Brave-Browser`` next to a used ``Brave-Origin``) must not shadow the
+    real one.
+
+    This predicate has to stay in sync with ``is_installed`` — pick a root
+    that ``is_installed`` then rejects and the browser reports "not found"
+    anyway. In particular ``Local State`` alone is NOT enough: an install
+    that was launched once and then abandoned has one, and would shadow
+    the root the user actually uses.
+    """
     try:
         return any(
-            entry.is_dir()
-            and ((entry / "Bookmarks").is_file() or (entry / "History").is_file())
+            entry.is_dir() and (entry / "Bookmarks").is_file()
             for entry in root.iterdir()
         )
     except OSError:
@@ -92,15 +96,36 @@ class ChromiumExtractor(BrowserExtractor):
 
     # ---------- detection ----------
 
+    def _linux_user_data_paths(self, home: Path) -> list[Path]:
+        """Linux candidates, resolved against ``$XDG_CONFIG_HOME``.
+
+        Chromium reads its User Data root from ``$XDG_CONFIG_HOME``
+        (default ``~/.config``), so a ``.config/...`` candidate has to
+        follow the variable when the user sets it. Snap and Flatpak
+        candidates carry their own container prefix and stay relative to
+        ``$HOME``. The XDG location comes first because that is the one
+        Chromium itself would use.
+        """
+        xdg = xdg_config_home()
+        out: list[Path] = []
+        for rel in self.user_data_dirs_linux:
+            if rel.startswith(".config/"):
+                out.append(xdg / rel[len(".config/"):])
+            out.append(home / rel)
+        # Dedupe, preserving order. ``xdg`` equals ``~/.config`` whenever
+        # the variable is unset, which is the common case.
+        seen: set[Path] = set()
+        return [p for p in out if not (p in seen or seen.add(p))]
+
     def _user_data_dir(self) -> Path | None:
         home = Path.home()
         if sys.platform == "darwin":
-            candidates = self.user_data_dirs_macos
+            paths = [home / rel for rel in self.user_data_dirs_macos]
         elif os.name == "nt":
-            candidates = self.user_data_dirs_windows
+            paths = [home / rel for rel in self.user_data_dirs_windows]
         else:
-            candidates = self.user_data_dirs_linux
-        existing = [home / rel for rel in candidates if (home / rel).is_dir()]
+            paths = self._linux_user_data_paths(home)
+        existing = [p for p in paths if p.is_dir()]
         # Prefer the first root that actually holds profile data, so a
         # leftover empty install dir can't shadow the one the user really
         # uses. Fall back to the first existing root, then to None.

--- a/src/extractors/chromium.py
+++ b/src/extractors/chromium.py
@@ -41,18 +41,29 @@ from .base import (
 logger = logging.getLogger(__name__)
 
 
-def _first_existing(paths) -> Path | None:
-    for p in paths:
-        if p and p.exists():
-            return p
-    return None
-
-
 # Synthetic-id namespaces. Folder/space ids in Arc are stable UUIDs; we
 # need our synthetic Chromium ids to be stable across runs too so the
 # Zen-side importers (which dedupe by id) don't double-create things.
 _NS_FOLDER = uuid.UUID("4e7b8d6a-9c33-4e2b-9fa3-1bd1d1ea2c41")
 _NS_SPACE = uuid.UUID("0ad3a9d9-95c0-4de1-87c1-2c41a9a3b1aa")
+
+
+def _root_has_profile(root: Path) -> bool:
+    """A Chromium User Data root is live if it carries a ``Local State``
+    file (created on first launch) or any profile subdirectory with a
+    ``Bookmarks`` / ``History`` file. An empty leftover install dir
+    (e.g. an abandoned ``Brave-Browser`` next to a used ``Brave-Origin``)
+    must not shadow the real one."""
+    if (root / "Local State").is_file():
+        return True
+    try:
+        return any(
+            entry.is_dir()
+            and ((entry / "Bookmarks").is_file() or (entry / "History").is_file())
+            for entry in root.iterdir()
+        )
+    except OSError:
+        return False
 
 
 class ChromiumExtractor(BrowserExtractor):
@@ -89,7 +100,14 @@ class ChromiumExtractor(BrowserExtractor):
             candidates = self.user_data_dirs_windows
         else:
             candidates = self.user_data_dirs_linux
-        return _first_existing(home / rel for rel in candidates)
+        existing = [home / rel for rel in candidates if (home / rel).is_dir()]
+        # Prefer the first root that actually holds profile data, so a
+        # leftover empty install dir can't shadow the one the user really
+        # uses. Fall back to the first existing root, then to None.
+        for root in existing:
+            if _root_has_profile(root):
+                return root
+        return existing[0] if existing else None
 
     def is_installed(self) -> bool:
         root = self._user_data_dir()

--- a/src/extractors/firefox.py
+++ b/src/extractors/firefox.py
@@ -60,6 +60,19 @@ _ROOT_IDS = {
 }
 
 
+def _xdg_config_home() -> Path:
+    """Resolve ``$XDG_CONFIG_HOME``, defaulting to ``~/.config``.
+
+    XDG-aware builds (increasingly common on Arch and other rolling
+    distros) keep browser data under ``$XDG_CONFIG_HOME/<vendor>`` rather
+    than the classic dotdir. Honour the variable when the user sets it.
+    """
+    env = os.environ.get("XDG_CONFIG_HOME")
+    if env:
+        return Path(env).expanduser()
+    return Path.home() / ".config"
+
+
 def _firefox_profiles_roots() -> list[Path]:
     """Every plausible Firefox profiles root for the current OS.
 
@@ -71,8 +84,11 @@ def _firefox_profiles_roots() -> list[Path]:
       ``%LOCALAPPDATA%\\Packages\\Mozilla.Firefox_<id>\\LocalCache\\Roaming\\Mozilla\\Firefox``.
       The standard path is empty for those installs, which is why both
       browser2zen and Zen's own importer otherwise miss a Store Firefox.
-    - Linux: a classic distro/apt install uses ``~/.mozilla/firefox``,
-      the Snap build (Ubuntu 22.04+ default) lives under
+    - Linux: a classic distro/apt install uses ``~/.mozilla/firefox``;
+      XDG-aware builds (Arch's ``firefox``, some others) put the
+      profiles root under ``$XDG_CONFIG_HOME/mozilla/firefox``
+      (``~/.config/mozilla/firefox`` by default); the Snap build
+      (Ubuntu 22.04+ default) lives under
       ``~/snap/firefox/common/.mozilla/firefox`` and the Flatpak build
       under ``~/.var/app/org.mozilla.firefox/.mozilla/firefox``.
 
@@ -97,6 +113,7 @@ def _firefox_profiles_roots() -> list[Path]:
         return roots
     return [
         home / ".mozilla/firefox",
+        _xdg_config_home() / "mozilla/firefox",
         home / "snap/firefox/common/.mozilla/firefox",
         home / ".var/app/org.mozilla.firefox/.mozilla/firefox",
     ]

--- a/src/extractors/firefox.py
+++ b/src/extractors/firefox.py
@@ -41,6 +41,7 @@ from .base import (
     FolderRecord,
     SpaceRecord,
     TabRecord,
+    xdg_config_home,
 )
 
 logger = logging.getLogger(__name__)
@@ -58,19 +59,6 @@ _ROOT_IDS = {
     5: "Other Bookmarks",
     6: "Mobile Bookmarks",
 }
-
-
-def _xdg_config_home() -> Path:
-    """Resolve ``$XDG_CONFIG_HOME``, defaulting to ``~/.config``.
-
-    XDG-aware builds (increasingly common on Arch and other rolling
-    distros) keep browser data under ``$XDG_CONFIG_HOME/<vendor>`` rather
-    than the classic dotdir. Honour the variable when the user sets it.
-    """
-    env = os.environ.get("XDG_CONFIG_HOME")
-    if env:
-        return Path(env).expanduser()
-    return Path.home() / ".config"
 
 
 def _firefox_profiles_roots() -> list[Path]:
@@ -113,7 +101,7 @@ def _firefox_profiles_roots() -> list[Path]:
         return roots
     return [
         home / ".mozilla/firefox",
-        _xdg_config_home() / "mozilla/firefox",
+        xdg_config_home() / "mozilla/firefox",
         home / "snap/firefox/common/.mozilla/firefox",
         home / ".var/app/org.mozilla.firefox/.mozilla/firefox",
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,20 @@ for path in (REPO_ROOT, REPO_ROOT / "src"):
         sys.path.insert(0, str(path))
 
 
+@pytest.fixture(autouse=True)
+def _clear_xdg_config_home(monkeypatch):
+    """Unset ``XDG_CONFIG_HOME`` for every test.
+
+    The Linux path lookups fall back to ``Path.home()/".config"`` only
+    when the variable is absent, and the tests redirect ``Path.home()``
+    into a tempdir. GitHub's Ubuntu runners export the variable, so
+    leaving it in place made the XDG tests pass on a developer's Mac and
+    fail in CI. Tests that exercise the variable set it themselves with
+    ``monkeypatch.setenv``, which still works on top of this.
+    """
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+
 # --- per-source fixture trees ---------------------------------------------
 # Each "tree" maps source-relative paths to home-relative destinations,
 # matching what the corresponding extractor's path lookups expect on real

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -361,6 +361,113 @@ def test_brave_extractor_detects_brave_origin(tmp_path, monkeypatch):
     assert urls == ["https://example.com/"]
 
 
+def test_brave_origin_survives_a_launched_then_abandoned_brave_browser(
+    tmp_path, monkeypatch
+):
+    """A ``Brave-Browser`` dir that was launched once and then abandoned
+    carries a ``Local State`` and a ``Default/History``, but no bookmarks.
+    It must not shadow a live ``Brave-Origin``: selecting it made
+    ``is_installed`` return False, i.e. the very "not found" symptom the
+    Brave-Origin support exists to fix."""
+    import json
+    import sys
+    from pathlib import Path
+
+    from extractors import BraveExtractor
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    # Abandoned install: launched (so Local State + History exist), but
+    # the user never bookmarked anything.
+    old = home / ".config/BraveSoftware/Brave-Browser"
+    (old / "Default").mkdir(parents=True)
+    (old / "Local State").write_text('{"profile": {}}', encoding="utf-8")
+    (old / "Default" / "History").write_bytes(b"\x00" * 64)
+
+    # The install actually in use.
+    origin = home / ".config/BraveSoftware/Brave-Origin"
+    (origin / "Default").mkdir(parents=True)
+    (origin / "Local State").write_text('{"profile": {}}', encoding="utf-8")
+    (origin / "Default" / "Bookmarks").write_text(json.dumps({
+        "roots": {
+            "bookmark_bar": {"children": [
+                {"type": "url", "name": "Example", "url": "https://example.com/"}
+            ]},
+            "other": {"children": []},
+            "synced": {"children": []},
+        },
+    }), encoding="utf-8")
+
+    ext = BraveExtractor()
+    assert ext._user_data_dir() == origin
+    assert ext.is_installed() is True
+    urls = sorted(t.url for t in (ext.extract().spaces[0].bookmarks or []))
+    assert urls == ["https://example.com/"]
+
+
+def test_chromium_user_data_dir_honours_xdg_config_home(tmp_path, monkeypatch):
+    """Chromium reads its User Data root from ``$XDG_CONFIG_HOME``, so a
+    ``.config/...`` candidate must follow the variable when the user sets
+    it. Firefox and Zen already honoured it; the Chromium family did
+    not."""
+    import json
+    import sys
+    from pathlib import Path
+
+    from extractors import BraveExtractor
+
+    home = tmp_path / "home"
+    home.mkdir()
+    xdg = tmp_path / "xdg"
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    root = xdg / "BraveSoftware/Brave-Browser"
+    (root / "Default").mkdir(parents=True)
+    (root / "Local State").write_text('{"profile": {}}', encoding="utf-8")
+    (root / "Default" / "Bookmarks").write_text(json.dumps({
+        "roots": {
+            "bookmark_bar": {"children": [
+                {"type": "url", "name": "Example", "url": "https://example.com/"}
+            ]},
+            "other": {"children": []},
+            "synced": {"children": []},
+        },
+    }), encoding="utf-8")
+
+    ext = BraveExtractor()
+    assert ext._user_data_dir() == root
+    assert ext.is_installed() is True
+
+
+def test_chromium_container_paths_ignore_xdg_config_home(tmp_path, monkeypatch):
+    """Snap and Flatpak candidates carry their own container prefix, so
+    they stay relative to ``$HOME`` even when ``XDG_CONFIG_HOME`` is
+    set."""
+    import sys
+    from pathlib import Path
+
+    from extractors import BraveExtractor
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    paths = BraveExtractor()._linux_user_data_paths(home)
+    flatpak = home / ".var/app/com.brave.Browser/config/BraveSoftware/Brave-Browser"
+    snap = home / "snap/brave/current/.config/BraveSoftware/Brave-Browser"
+    assert flatpak in paths
+    assert snap in paths
+    # The XDG root is preferred over ~/.config for the plain install.
+    assert paths[0] == tmp_path / "xdg/BraveSoftware/Brave-Browser"
+
+
 def test_unknown_source_raises():
     from extractors import by_name
     with pytest.raises(KeyError):

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -177,6 +177,7 @@ def test_firefox_extractor_skips_disabled_root(firefox_home):
 @pytest.mark.parametrize(
     "root_rel",
     [
+        ".config/mozilla/firefox",                              # Arch XDG-config layout
         "snap/firefox/common/.mozilla/firefox",                 # Ubuntu Snap
         ".var/app/org.mozilla.firefox/.mozilla/firefox",        # Flatpak
     ],
@@ -184,9 +185,10 @@ def test_firefox_extractor_skips_disabled_root(firefox_home):
 def test_firefox_extractor_detects_linux_packaged_install(
     tmp_path, monkeypatch, root_rel
 ):
-    """Snap/Flatpak Firefox keeps its profiles outside ``~/.mozilla``;
-    detection must find those too (regression for the Reddit report that
-    Firefox wasn't detected)."""
+    """Snap/Flatpak/XDG-config Firefox keeps its profiles outside
+    ``~/.mozilla``; detection must find those too (regression for the
+    Reddit report that Firefox wasn't detected, and the Arch report where
+    profiles live under ``~/.config/mozilla/firefox``)."""
     import shutil
     import sys
     from pathlib import Path
@@ -212,6 +214,36 @@ def test_firefox_extractor_detects_linux_packaged_install(
     data = ext.extract()
     assert data.source == "firefox"
     assert len(data.spaces) == 1
+
+
+def test_firefox_extractor_honours_xdg_config_home(tmp_path, monkeypatch):
+    """When the user sets ``XDG_CONFIG_HOME`` explicitly, Firefox's
+    profiles root must follow it (the profiles root is
+    ``$XDG_CONFIG_HOME/mozilla/firefox`` on XDG-aware builds)."""
+    import shutil
+    import sys
+    from pathlib import Path
+
+    from extractors import FirefoxExtractor
+
+    fixtures = Path(__file__).resolve().parent / "fixtures" / "firefox"
+    home = tmp_path / "home"
+    home.mkdir()
+    xdg_config = tmp_path / "xdg"
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_config))
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    root_rel = "mozilla/firefox"
+    for src in fixtures.rglob("*"):
+        if src.is_file():
+            dest = xdg_config / root_rel / src.relative_to(fixtures)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dest)
+
+    ext = FirefoxExtractor()
+    assert ext.is_installed() is True
+    assert len(ext.profile_paths()) == 1
 
 
 def test_firefox_extractor_detects_windows_store_msix(tmp_path, monkeypatch):
@@ -282,6 +314,51 @@ def test_edge_extractor_registered():
 def test_brave_extractor_registered():
     from extractors import BraveExtractor, by_name
     assert by_name("brave") is BraveExtractor
+
+
+def test_brave_extractor_detects_brave_origin(tmp_path, monkeypatch):
+    """Brave Origin (official ``brave-origin-bin`` AUR package) keeps its
+    User Data under ``~/.config/BraveSoftware/Brave-Origin`` instead of
+    ``Brave-Browser``. Detection must find it, even when a leftover empty
+    ``Brave-Browser`` directory is also present (regression for the Arch
+    report where Brave showed as "not found")."""
+    import json
+    import sys
+    from pathlib import Path
+
+    from extractors import BraveExtractor
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    origin = home / ".config/BraveSoftware/Brave-Origin"
+    (origin / "Default").mkdir(parents=True)
+    (origin / "Local State").write_text('{"profile": {}}', encoding="utf-8")
+    (origin / "Default" / "Bookmarks").write_text(json.dumps({
+        "roots": {
+            "bookmark_bar": {
+                "children": [
+                    {"type": "url", "name": "Example", "url": "https://example.com/"}
+                ]
+            },
+            "other": {"children": []},
+            "synced": {"children": []},
+        },
+    }), encoding="utf-8")
+
+    # A leftover, never-launched Brave-Browser install must NOT shadow it.
+    (home / ".config/BraveSoftware/Brave-Browser/NativeMessagingHosts").mkdir(parents=True)
+
+    ext = BraveExtractor()
+    assert ext.is_installed() is True
+    roots = [p.name for p in ext.profile_paths()]
+    assert roots == ["Default"]
+    data = ext.extract()
+    assert data.source == "brave"
+    urls = sorted(t.url for t in (data.spaces[0].bookmarks or []))
+    assert urls == ["https://example.com/"]
 
 
 def test_unknown_source_raises():

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -79,6 +79,39 @@ def test_check_environment_finds_zen_under_xdg_config_home(tmp_path, monkeypatch
     assert str(env.zen_profiles[0].path).startswith(str(home / ".config/zen"))
 
 
+def test_check_environment_finds_zen_under_flatpak(tmp_path, monkeypatch):
+    """Zen Flatpak (app.zen_browser.zen) keeps its profiles under the
+    sandbox home ``~/.var/app/app.zen_browser.zen/.zen``; detection must
+    find those (issue #5: Flatpak version not detected on Linux)."""
+    import shutil
+    import sys
+    from pathlib import Path
+
+    from app.orchestrator import MigrationOrchestrator
+    from extractors import ArcExtractor
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    fixtures = Path(__file__).resolve().parent / "fixtures" / "zen"
+    src_profile = fixtures / "Profiles/test.default (release)"
+    dest_profile = home / ".var/app/app.zen_browser.zen/.zen/test.default (release)"
+    dest_profile.mkdir(parents=True)
+    for f in src_profile.iterdir():
+        if f.is_file():
+            shutil.copy2(f, dest_profile / f.name)
+
+    o = MigrationOrchestrator(source=ArcExtractor())
+    env = o.check_environment()
+    assert env.zen_installed is True
+    assert len(env.zen_profiles) >= 1
+    assert str(env.zen_profiles[0].path).startswith(
+        str(home / ".var/app/app.zen_browser.zen/.zen")
+    )
+
+
 def test_stale_zen_root_does_not_shadow_live_xdg_profile(tmp_path, monkeypatch):
     """A leftover empty ``~/.zen/profiles.ini`` from an uninstalled Zen
     must not shadow a live profile under ``~/.config/zen`` (regression:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -147,6 +147,66 @@ def test_stale_zen_root_does_not_shadow_live_xdg_profile(tmp_path, monkeypatch):
     assert str(env.zen_profiles[0].path).startswith(str(home / ".config/zen"))
 
 
+def test_zen_lists_profiles_from_every_root(tmp_path, monkeypatch):
+    """A native Zen and a Flatpak Zen can be installed side by side. Both
+    profiles must reach the picker: choosing a single root hid the Flatpak
+    one whenever ``~/.zen`` also held a live profile, which is exactly the
+    Flatpak-first case in issue #5."""
+    import sys
+    from pathlib import Path
+
+    from app.orchestrator import MigrationOrchestrator
+    from extractors import ArcExtractor
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    native = home / ".zen/aaa.default (release)"
+    flatpak = home / ".var/app/app.zen_browser.zen/.zen/bbb.default (release)"
+    for p in (native, flatpak):
+        p.mkdir(parents=True)
+        (p / "places.sqlite").write_bytes(b"\x00" * 64)
+
+    o = MigrationOrchestrator(source=ArcExtractor())
+    env = o.check_environment()
+    assert env.zen_installed is True
+    paths = {str(p.path) for p in env.zen_profiles}
+    assert paths == {str(native), str(flatpak)}
+    # The install label disambiguates two identically-named profiles.
+    installs = {str(p.path): p.install for p in env.zen_profiles}
+    assert installs[str(native)] == ""
+    assert installs[str(flatpak)] == "Flatpak"
+
+
+def test_zen_classic_root_stays_first_when_both_are_live(tmp_path, monkeypatch):
+    """With several live roots the classic ``~/.zen`` profile stays the
+    default selection, so a single-install machine keeps its old target."""
+    import sys
+    from pathlib import Path
+
+    from app.orchestrator import MigrationOrchestrator
+    from extractors import ArcExtractor
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    # Same profile name under both roots — only the root differs.
+    native = home / ".zen/abc.default (release)"
+    xdg = home / ".config/zen/abc.default (release)"
+    for p in (native, xdg):
+        p.mkdir(parents=True)
+        (p / "places.sqlite").write_bytes(b"\x00" * 64)
+
+    o = MigrationOrchestrator(source=ArcExtractor())
+    env = o.check_environment()
+    assert len(env.zen_profiles) == 2
+    assert str(env.zen_profiles[0].path) == str(native)
+
+
 def test_excluded_spaces_filter(chrome_home, zen_profile):
     """The orchestrator drops any space whose name is in
     excluded_spaces before lowering to the legacy dict."""

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -45,6 +45,75 @@ def test_check_environment_uses_source(arc_home, zen_profile):
     assert env.zen_installed is True
 
 
+def test_check_environment_finds_zen_under_xdg_config_home(tmp_path, monkeypatch):
+    """Zen on Arch-style XDG-config installs keeps its profiles under
+    ``~/.config/zen`` rather than ``~/.zen``; detection must find those
+    (same root cause as the Firefox/Brave "not found" report)."""
+    import shutil
+    import sys
+    from pathlib import Path
+
+    from extractors import ArcExtractor
+    from app.orchestrator import MigrationOrchestrator
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    # Copy the Zen fixture under the XDG layout. Linux Zen keeps profiles
+    # flat in the root (~/.zen/<profile>, ~/.config/zen/<profile>), not
+    # under a macOS-style ``Profiles/`` subdirectory.
+    fixtures = Path(__file__).resolve().parent / "fixtures" / "zen"
+    src_profile = fixtures / "Profiles/test.default (release)"
+    dest_profile = home / ".config/zen/test.default (release)"
+    dest_profile.mkdir(parents=True)
+    for f in src_profile.iterdir():
+        if f.is_file():
+            shutil.copy2(f, dest_profile / f.name)
+
+    o = MigrationOrchestrator(source=ArcExtractor())
+    env = o.check_environment()
+    assert env.zen_installed is True
+    assert len(env.zen_profiles) >= 1
+    assert str(env.zen_profiles[0].path).startswith(str(home / ".config/zen"))
+
+
+def test_stale_zen_root_does_not_shadow_live_xdg_profile(tmp_path, monkeypatch):
+    """A leftover empty ``~/.zen/profiles.ini`` from an uninstalled Zen
+    must not shadow a live profile under ``~/.config/zen`` (regression:
+    root-picker used to prefer any root with a profiles.ini, making Zen
+    look \"not installed\" on Arch upgrades)."""
+    import sys
+    from pathlib import Path
+
+    from extractors import ArcExtractor
+    from app.orchestrator import MigrationOrchestrator
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    # Stale ~/.zen with a profiles.ini but no real profile data.
+    stale = home / ".zen"
+    stale.mkdir(parents=True)
+    (stale / "profiles.ini").write_text(
+        "[Profile0]\nPath=abc.default\n", encoding="utf-8"
+    )
+
+    # The live profile lives under the XDG layout.
+    dest_profile = home / ".config/zen/abc.default (release)"
+    dest_profile.mkdir(parents=True)
+    (dest_profile / "places.sqlite").write_bytes(b"\x00" * 64)
+
+    o = MigrationOrchestrator(source=ArcExtractor())
+    env = o.check_environment()
+    assert env.zen_installed is True
+    assert len(env.zen_profiles) >= 1
+    assert str(env.zen_profiles[0].path).startswith(str(home / ".config/zen"))
+
+
 def test_excluded_spaces_filter(chrome_home, zen_profile):
     """The orchestrator drops any space whose name is in
     excluded_spaces before lowering to the legacy dict."""

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -53,8 +53,8 @@ def test_check_environment_finds_zen_under_xdg_config_home(tmp_path, monkeypatch
     import sys
     from pathlib import Path
 
-    from extractors import ArcExtractor
     from app.orchestrator import MigrationOrchestrator
+    from extractors import ArcExtractor
 
     home = tmp_path / "home"
     home.mkdir()
@@ -87,8 +87,8 @@ def test_stale_zen_root_does_not_shadow_live_xdg_profile(tmp_path, monkeypatch):
     import sys
     from pathlib import Path
 
-    from extractors import ArcExtractor
     from app.orchestrator import MigrationOrchestrator
+    from extractors import ArcExtractor
 
     home = tmp_path / "home"
     home.mkdir()


### PR DESCRIPTION
On Arch Linux, browser data lives under $XDG_CONFIG_HOME instead of the classic dotdirs, so Brave, Firefox, and Zen all showed as "Not found" even when installed.
## What changed

- Brave (src/extractors/brave.py): detect the Brave-Origin build (official brave-origin-bin AUR package), which keeps its User Data under ~/.config/BraveSoftware/Brave-Origin[-Beta|-Nightly] instead of Brave-Browser.
- Firefox (src/extractors/firefox.py): add $XDG_CONFIG_HOME/mozilla/firefox (default ~/.config/mozilla/firefox) alongside the classic, Snap, and Flatpak roots.
- Zen (app/env_check.py): add $XDG_CONFIG_HOME/zen (default ~/.config/zen) alongside ~/.zen.
- Chromium root selection (src/extractors/chromium.py): prefer the first User Data root that actually holds profile data, so a leftover empty install dir (e.g. an abandoned Brave-Browser) can't shadow the one in use.
- Zen root selection (app/env_check.py): prefer the root with a live profile, so a stale profiles.ini from an uninstalled old Zen doesn't make Zen report "not installed".
- Zen: add the Flatpak sandbox home ~/.var/app/app.zen_browser.zen/.zen (fixes issue #5)
- Tests: regression coverage for Brave-Origin (incl. leftover-dir shadowing), XDG Firefox ($XDG_CONFIG_HOME honoured), XDG Zen, and the stale ~/.zen edge case.


## Verification


- Live smoke test on the reporter's Arch machine: Brave, Firefox, and Zen all detected; Brave extracts 1 pinned + 9 open tabs + 197 bookmarks.
- pytest: 73 passed, 1 skipped.
- ruff check: clean.
- macOS/Windows paths are untouched; simulated-macOS tests confirm no regression.